### PR TITLE
Adjusted controller regex

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -126,7 +126,7 @@ function checkControllers (pathName, methodName, methodSection, controllersLocat
 
     try {
       if (Array.isArray(controllersLocation)) {
-        const ctrlRegex = new RegExp(controller + '.js$')
+        const ctrlRegex = new RegExp('/' + controller + '.js$')
 
         ctrlLocation = controllersLocation.find((location) => ctrlRegex.test(location))
         load = require(pathModule.join(ctrlLocation.replace(ctrlRegex, ''), utils.generateName(`${controller}.js`, undefined)))

--- a/src/middleware/oas-router.js
+++ b/src/middleware/oas-router.js
@@ -204,7 +204,7 @@ module.exports = (controllers) => {
 
     try {
       if (Array.isArray(controllers)) {
-        const ctrlRegex = new RegExp(controllerName)
+        const ctrlRegex = new RegExp('/' + controllerName)
         const targetController = controllers.find((ctrl) => ctrlRegex.test(ctrl))
 
         controller = require(targetController)


### PR DESCRIPTION
Adjusted controller regex to avoid fetching controllers whose filename is a substring of another. (e.g.: user.controller.js and admin.user.controller.js